### PR TITLE
feat: 添加 --tc-priority 选项以配置 TC filter 优先级

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ sudo ./bandix --iface <network_interface_name> [options]
 - **--port**: Web server listening port. Default: `8686`
 - **--data-dir**: Data directory (ring files and rate limit configurations will be stored here). Default: `bandix-data`
 - **--log-level**: Log level: trace, debug, info, warn, error (default: info). Web and DNS logs are always at DEBUG level.
+- **--tc-priority**: TC filter priority (lower number = higher priority, 0 = kernel auto-assign). Default: 0. Use this to control execution order when running alongside other eBPF TC programs.
 - **--web-log**: Enable per-request web logging. Default: `false`
 - **--enable-traffic**: Enable traffic monitoring module. Default: `false`
 - **--traffic-retention-seconds**: Retention duration (seconds) for real-time metrics, i.e., ring file capacity (one slot per second). Default: `600`
@@ -75,6 +76,12 @@ sudo ./bandix --iface br-lan --enable-traffic --enable-connection --enable-dns
 
 # Custom port and data directory
 sudo ./bandix --iface br-lan --port 8080 --data-dir /var/lib/bandix --enable-traffic --enable-connection --enable-dns
+
+# Run bandix with higher priority (execute before other TC programs)
+sudo ./bandix --iface br-lan --tc-priority 1 --enable-traffic
+
+# Run bandix with lower priority (execute after other TC programs)
+sudo ./bandix --iface br-lan --tc-priority 10 --enable-traffic
 ```
 
 ## API Endpoints

--- a/README.zh.md
+++ b/README.zh.md
@@ -49,6 +49,7 @@ sudo ./bandix --iface <网络接口名称> [选项]
 - **--port**: Web 服务器监听端口。默认值：`8686`
 - **--data-dir**: 数据目录（环形文件和限速配置将存储在此处）。默认值：`bandix-data`
 - **--log-level**: 日志级别：trace, debug, info, warn, error（默认：info）。Web 和 DNS 日志始终为 DEBUG 级别。
+- **--tc-priority**: TC filter 优先级（数字越小优先级越高，0 = 内核自动分配）。默认值：0。用于控制与其他 eBPF TC 程序共存时的执行顺序。
 - **--web-log**: 启用每个请求的 Web 日志记录。默认值：`false`
 - **--enable-traffic**: 启用流量监控模块。默认值：`false`
 - **--traffic-retention-seconds**: 实时指标的保留时长（秒），即环形文件容量（每秒一个槽位）。默认值：`600`
@@ -75,6 +76,12 @@ sudo ./bandix --iface br-lan --enable-traffic --enable-connection --enable-dns
 
 # 自定义端口和数据目录
 sudo ./bandix --iface br-lan --port 8080 --data-dir /var/lib/bandix --enable-traffic --enable-connection --enable-dns
+
+# 以较高优先级运行 bandix（在其他 TC 程序之前执行）
+sudo ./bandix --iface br-lan --tc-priority 1 --enable-traffic
+
+# 以较低优先级运行 bandix（在其他 TC 程序之后执行）
+sudo ./bandix --iface br-lan --tc-priority 10 --enable-traffic
 ```
 
 ## API 接口

--- a/bandix/src/ebpf/shared.rs
+++ b/bandix/src/ebpf/shared.rs
@@ -1,13 +1,21 @@
 use super::remove_rlimit_memlock;
-use aya::programs::{tc, SchedClassifier, TcAttachType};
+use aya::programs::tc::{self, NlOptions, SchedClassifier, TcAttachOptions, TcAttachType};
 
 /// 加载共享的 eBPF 程序（入口和出口）
 /// DNS 和流量模块共享相同的入口和出口钩子
 /// 返回未包装的 eBPF 对象，以便在包装到 Arc 之前配置映射
-pub async fn load_shared(iface: String) -> anyhow::Result<aya::Ebpf> {
+///
+/// # Arguments
+/// * `iface` - 要监控的网络接口名称
+/// * `tc_priority` - TC filter 优先级（0 表示使用内核默认值）
+pub async fn load_shared(iface: String, tc_priority: u16) -> anyhow::Result<aya::Ebpf> {
     remove_rlimit_memlock();
 
-    log::info!("Loading shared eBPF programs (ingress and egress) for interface {}", iface);
+    log::info!(
+        "Loading shared eBPF programs for interface {} with TC priority {}",
+        iface,
+        if tc_priority == 0 { "auto".to_string() } else { tc_priority.to_string() }
+    );
 
     // 一次性加载 eBPF 对象 - 入口和出口程序都在同一个对象中
     // 这确保它们共享相同的映射（DNS_DATA、MAC_TRAFFIC、MAC_RATE_LIMITS 等）
@@ -20,7 +28,7 @@ pub async fn load_shared(iface: String) -> anyhow::Result<aya::Ebpf> {
         log::debug!("Failed to add clsact qdisc (may already exist): {}", e);
     }
 
-    // 加载and attach shared ingress program
+    // 加载 shared ingress program
     let ingress_program: &mut SchedClassifier = ebpf
         .program_mut("shared_ingress")
         .ok_or_else(|| anyhow::anyhow!("Shared ingress program not found in eBPF object"))?
@@ -31,9 +39,21 @@ pub async fn load_shared(iface: String) -> anyhow::Result<aya::Ebpf> {
         .load()
         .map_err(|e| anyhow::anyhow!("Failed to load shared ingress program: {}", e))?;
 
-    ingress_program
-        .attach(&iface, TcAttachType::Ingress)
-        .map_err(|e| anyhow::anyhow!("Failed to attach shared ingress program to {}: {}", iface, e))?;
+    // 根据 tc_priority 选择 attach 方式
+    if tc_priority > 0 {
+        let nl_options = NlOptions {
+            priority: tc_priority,
+            handle: 0, // 让系统自动分配 handle
+        };
+        ingress_program
+            .attach_with_options(&iface, TcAttachType::Ingress, TcAttachOptions::Netlink(nl_options))
+            .map_err(|e| anyhow::anyhow!("Failed to attach shared ingress program to {}: {}", iface, e))?;
+    } else {
+        // tc_priority == 0: 使用默认行为（内核自动分配优先级）
+        ingress_program
+            .attach(&iface, TcAttachType::Ingress)
+            .map_err(|e| anyhow::anyhow!("Failed to attach shared ingress program to {}: {}", iface, e))?;
+    }
 
     log::info!("Shared ingress program successfully attached to {}", iface);
 
@@ -48,12 +68,25 @@ pub async fn load_shared(iface: String) -> anyhow::Result<aya::Ebpf> {
         .load()
         .map_err(|e| anyhow::anyhow!("Failed to load shared egress program: {}", e))?;
 
-    egress_program
-        .attach(&iface, TcAttachType::Egress)
-        .map_err(|e| anyhow::anyhow!("Failed to attach shared egress program to {}: {}", iface, e))?;
+    // 根据 tc_priority 选择 attach 方式
+    if tc_priority > 0 {
+        let nl_options = NlOptions {
+            priority: tc_priority,
+            handle: 0,
+        };
+        egress_program
+            .attach_with_options(&iface, TcAttachType::Egress, TcAttachOptions::Netlink(nl_options))
+            .map_err(|e| anyhow::anyhow!("Failed to attach shared egress program to {}: {}", iface, e))?;
+    } else {
+        egress_program
+            .attach(&iface, TcAttachType::Egress)
+            .map_err(|e| anyhow::anyhow!("Failed to attach shared egress program to {}: {}", iface, e))?;
+    }
 
     log::info!("Shared egress program successfully attached to {}", iface);
-    log::info!("Shared eBPF programs loaded and attached. DNS and traffic modules share the same ingress and egress hooks.");
+    log::info!(
+        "Shared eBPF programs loaded and attached. DNS and traffic modules share the same ingress and egress hooks."
+    );
 
     // 返回未包装的 eBPF 对象，以便在包装到 Arc 之前配置映射
     Ok(ebpf)


### PR DESCRIPTION
## 概述

添加新的命令行选项 `--tc-priority`，允许用户在 attach eBPF 程序时配置 TC (Traffic Control) filter 优先级。这使得 bandix 能够更好地与其他 eBPF TC 程序共存。

## 背景

当 bandix 与其他 eBPF TC 程序一起运行时，TC filter 链的执行顺序可能会发生冲突。目前 bandix 使用 `SchedClassifier::attach()` 而不指定优先级，这让内核分配默认优先级（通常是 49152）。

这意味着用户无法控制 bandix 的 TC filter 相对于其他程序的执行时机。

## 更改内容

1. **command.rs**: 在 [CommonArgs] 中添加 `--tc-priority` 选项
2. **ebpf/shared.rs**: 将 [attach()] 改为 [attach_with_options()] 以支持可配置优先级

## 使用方法

```bash
# 以较高优先级运行 bandix（在其他 TC 程序之前执行）
bandix --iface br-lan --tc-priority 1 --enable-traffic

# 以较低优先级运行 bandix（在其他 TC 程序之后执行）
bandix --iface br-lan --tc-priority 10 --enable-traffic

# 使用内核默认优先级（0 表示内核自动分配）
bandix --iface br-lan --enable-traffic
```

## 测试
- 使用 tc filter show dev <iface> ingress 验证 TC filter 优先级
- 使用 cargo check 编译验证通过
---